### PR TITLE
Fix dots animation and add ESC key modal close

### DIFF
--- a/src/app/components/Leaderboard.tsx
+++ b/src/app/components/Leaderboard.tsx
@@ -61,6 +61,22 @@ export function Leaderboard({ initialData }: { initialData: Lemonade[] }) {
     return () => { document.body.style.overflow = ''; };
   }, [modalOpen]);
 
+  useEffect(() => {
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        if (showAddModal && !submitting && !uploading) {
+          setShowAddModal(false);
+          setFileName(null);
+        }
+        if (showRules) {
+          setShowRules(false);
+        }
+      }
+    }
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [showAddModal, showRules, submitting, uploading]);
+
   const rankMap = new Map<string, number>();
   [...initialData]
     .sort((a, b) => b.overall_score - a.overall_score || new Date(a.created_at).getTime() - new Date(b.created_at).getTime())

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -459,18 +459,18 @@ td.empty {
 }
 
 @keyframes dots {
-  0% { content: ''; }
-  25% { content: '.'; }
-  50% { content: '..'; }
-  75% { content: '...'; }
+  0% { clip-path: inset(0 100% 0 0); }
+  25% { clip-path: inset(0 1em 0 0); }
+  50% { clip-path: inset(0 0.5em 0 0); }
+  75%, 100% { clip-path: inset(0 0 0 0); }
 }
 
 .dots::after {
-  content: '';
+  content: '...';
   display: inline-block;
   width: 1.5em;
   text-align: left;
-  animation: dots 1.2s steps(1) infinite;
+  animation: dots 1.2s steps(4) infinite;
 }
 
 /* --- Mobile --- */


### PR DESCRIPTION
## Summary
- Replace unsupported `content` animation with `clip-path` for loading dots (browsers don't support animating the `content` property)
- Keep fixed `width: 1.5em` to prevent button text shift
- Add ESC key handler to close modals on desktop (respects submitting/uploading states)