### PR TITLE
feat: add staging environment and auto-deploy workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: ci
 on:
   pull_request:
   push:
-    branches: [main]
+    branches: [main, staging]
 
 jobs:
   quality:

--- a/.github/workflows/db-migrate.yml
+++ b/.github/workflows/db-migrate.yml
@@ -1,0 +1,36 @@
+name: db-migrate
+
+on:
+  push:
+    branches: [main, staging]
+    paths:
+      - 'supabase/migrations/**'
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: supabase/setup-cli@v1
+        with:
+          version: latest
+      
+      - name: Link and migrate staging
+        if: github.ref == 'refs/heads/staging'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_STAGING_DB_PASSWORD }}
+        run: |
+          supabase link --project-ref xduxzpriixkxrygulgon -p "$SUPABASE_DB_PASSWORD"
+          supabase db push --linked
+      
+      - name: Link and migrate production
+        if: github.ref == 'refs/heads/main'
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_DB_PASSWORD: ${{ secrets.SUPABASE_PRODUCTION_DB_PASSWORD }}
+        run: |
+          supabase link --project-ref mpbpzxkttsqmsaazxbkk -p "$SUPABASE_DB_PASSWORD"
+          supabase db push --linked

--- a/README.md
+++ b/README.md
@@ -43,4 +43,5 @@ scripts
 
 docs
 - `docs/TESTING.md` — testing strategy, conventions, troubleshooting
+- `docs/DEPLOYMENT.md` — staging/prod workflow
 - `docs/planning/` — roadmap, status, workflow

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,35 @@
+# Deployment
+
+## Workflow
+
+```
+push staging → CI → DB migrate (staging) → Vercel preview
+push main    → CI → DB migrate (prod)    → Vercel production
+```
+
+DB migrations only run if `supabase/migrations/**` files changed.
+
+## GitHub Secrets Required
+
+| Secret | Description |
+|--------|-------------|
+| `SUPABASE_ACCESS_TOKEN` | From supabase.com/dashboard/account/tokens |
+| `SUPABASE_STAGING_DB_PASSWORD` | Staging DB password |
+| `SUPABASE_PRODUCTION_DB_PASSWORD` | Production DB password |
+
+## Vercel Environments
+
+| Environment | Branch | Uses |
+|-------------|--------|------|
+| Production | `main` | Production DB |
+| Preview | `staging` | Staging DB |
+| Preview | other branches | Staging/dev DB |
+
+Configure env vars (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY`) in the Vercel dashboard per environment, or sync from Infisical using the [Infisical Vercel integration](https://infisical.com/docs/integrations/cloud/vercel).
+
+## Manual Deploy
+
+```bash
+vercel        # Deploy to preview
+vercel --prod # Deploy to production
+```

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
Das ist ein alter PR aber davon waren einige changes nicht mehr nötig wegen dem neuen secrets system.


Supersedes #6 — clean version without .env file management (that is handled by Infisical in #13).

## Summary

- Add `.github/workflows/db-migrate.yml`: auto-runs `supabase db push` on push to `main`/`staging` when migrations change
- Add `vercel.json`: Vercel framework config for Next.js
- Update `.github/workflows/ci.yml`: run CI on `staging` branch as well as `main`
- Add `docs/DEPLOYMENT.md`: staging/prod workflow docs, references Infisical for env vars

## GitHub Secrets Required

| Secret | Description |
|--------|-------------|
| `SUPABASE_ACCESS_TOKEN` | From supabase.com/dashboard/account/tokens |
| `SUPABASE_STAGING_DB_PASSWORD` | Staging DB password |
| `SUPABASE_PRODUCTION_DB_PASSWORD` | Production DB password |

## Test plan

- [ ] Push a migration to `staging` branch and verify db-migrate workflow runs
- [ ] Verify Vercel preview deploys on `staging` push

Made with [Cursor](https://cursor.com)