### PR TITLE
Feat/admin mode

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -19,7 +19,7 @@ How we test this project and how to add tests for new features.
 
 - **Zod schemas** — validation rules, edge cases
 - **Pure functions** — e.g. `isAllowedImageUrl` in `src/lib/image-url.ts`
-- **Server actions** — mock `createLemonade`, test validation and error paths
+- **Server actions** — mock `createLemonade`, test validation and error paths; admin actions (`deleteLemonade`, `editLemonade`, `logoutAdmin`) in `tests/unit/admin-actions.test.ts`
 
 ### Conventions
 
@@ -58,8 +58,14 @@ E2E files run in **alphabetical order**. Numbered prefixes enforce the right seq
 
 - `01-smoke.spec.ts` — runs first (page load, empty state)
 - `02-add-lemonade.spec.ts` — runs second (adds data to DB)
+- `03-login.spec.ts` — login page, invalid credentials, login with test admin and see logout
+- `04-admin-delete-edit.spec.ts` — admin edit then delete (depends on 02 for row data)
 
 **Why:** The empty-state test expects no entries. If add-lemonade ran first, it would pollute the DB and the empty-state test would fail.
+
+### Admin E2E
+
+Admin tests (03, 04) need an authenticated user. When you run `npm run test:e2e`, the script creates a test admin user via the Supabase Auth Admin API after `db reset` (using the local Supabase secret key from `supabase status`). It sets `TEST_ADMIN_EMAIL` and `TEST_ADMIN_PASSWORD` in the environment so Playwright can log in. If the secret key is not available, the admin user is not created and 03/04 tests that require it will skip. For `npm run test:e2e:local`, set these env vars yourself if you want admin tests to run (e.g. create a user in Supabase Studio and export the credentials).
 
 ### Database State
 

--- a/scripts/e2e-ci.mjs
+++ b/scripts/e2e-ci.mjs
@@ -75,10 +75,45 @@ function waitForSupabase(maxAttempts = 30) {
 function getSupabaseEnv(status) {
   const apiUrl = status.API_URL || status.api_url || 'http://127.0.0.1:54321';
   const publishableKey = status.PUBLISHABLE_KEY || status.publishable_key || status.ANON_KEY || status.anon_key || '';
+  const secretKey = status.SECRET_KEY || status.secret_key || status.service_role_key || status.SERVICE_ROLE_KEY || '';
   return {
     NEXT_PUBLIC_SUPABASE_URL: apiUrl,
     NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: publishableKey,
+    secretKey,
   };
+}
+
+const TEST_ADMIN_EMAIL = 'e2e-admin@test.local';
+const TEST_ADMIN_PASSWORD = 'e2e-admin-password';
+
+async function createTestAdminUser(apiUrl, serviceRoleKey) {
+  if (!serviceRoleKey) return false;
+  const url = `${apiUrl.replace(/\/$/, '')}/auth/v1/admin/users`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${serviceRoleKey}`,
+        apikey: serviceRoleKey,
+      },
+      body: JSON.stringify({
+        email: TEST_ADMIN_EMAIL,
+        password: TEST_ADMIN_PASSWORD,
+        email_confirm: true,
+      }),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      if (res.status === 422 && text.includes('already been registered')) return true;
+      log(`  Admin user create: ${res.status} ${text}`, '\x1b[33m');
+      return false;
+    }
+    return true;
+  } catch (err) {
+    log(`  Admin user create failed: ${err.message}`, '\x1b[33m');
+    return false;
+  }
 }
 
 function waitForServer(url, maxAttempts = 30) {
@@ -118,6 +153,16 @@ async function main() {
   const env = getSupabaseEnv(status);
   Object.assign(process.env, env);
   process.env.PLAYWRIGHT_BASE_URL = BASE_URL;
+
+  if (env.secretKey) {
+    log('Creating test admin user...', '\x1b[36m');
+    const created = await createTestAdminUser(env.NEXT_PUBLIC_SUPABASE_URL, env.secretKey);
+    if (created) {
+      process.env.TEST_ADMIN_EMAIL = TEST_ADMIN_EMAIL;
+      process.env.TEST_ADMIN_PASSWORD = TEST_ADMIN_PASSWORD;
+      log('Test admin user ready', '\x1b[32m');
+    }
+  }
 
   log(`Starting Next.js on port ${PORT}...`, '\x1b[36m');
   const nextProcess = spawn('npm', ['run', 'dev:next', '--', '--port', String(PORT)], {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -1,7 +1,14 @@
 'use server';
 
 import { revalidatePath } from 'next/cache';
-import { createLemonade } from '@/services/lemonade-service';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import {
+  createLemonade,
+  deleteLemonade as deleteLemonadeService,
+  updateLemonade,
+  deleteStorageImage,
+} from '@/services/lemonade-service';
 import { isAllowedImageUrl } from '@/lib/image-url';
 import { lemonadeFormSchema } from '@/types/lemonade';
 
@@ -43,8 +50,24 @@ export async function addLemonade(data: {
   return { success: true };
 }
 
-/** Stub until admin mode implements real edit. LemonadeFormModal calls this in edit mode. */
-export async function editLemonade(_data: {
+export async function deleteLemonade(
+  id: string,
+  imageUrl?: string | null
+): Promise<{ success: true } | { error: string }> {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated.' };
+
+  try {
+    await deleteLemonadeService(id, imageUrl ?? null);
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to delete.' };
+  }
+  revalidatePath('/');
+  return { success: true };
+}
+
+export async function editLemonade(data: {
   id: string;
   name: string;
   description: string;
@@ -53,6 +76,51 @@ export async function editLemonade(_data: {
   imageUrl?: string;
   locationCity?: string;
   addedBy?: string;
+  oldImageUrl?: string | null;
+  imageRemoved?: boolean;
 }): Promise<{ success: true } | { error: string }> {
-  return { error: 'Edit is not available yet.' };
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: 'Not authenticated.' };
+
+  const parsed = lemonadeFormSchema.safeParse({
+    ...data,
+    imageUrl: data.imageUrl ?? '',
+    locationCity: data.locationCity ?? '',
+    addedBy: data.addedBy ?? '',
+  });
+  if (!parsed.success) {
+    const firstError = Object.values(parsed.error.flatten().fieldErrors).flat()[0];
+    return { error: firstError || 'Invalid input' };
+  }
+
+  if (parsed.data.imageUrl && !isAllowedImageUrl(parsed.data.imageUrl)) {
+    return { error: 'Image URL must be from your storage bucket' };
+  }
+
+  try {
+    if (data.oldImageUrl && (data.imageRemoved || data.imageUrl)) {
+      await deleteStorageImage(data.oldImageUrl);
+    }
+    await updateLemonade(data.id, {
+      name: data.name,
+      description: data.description,
+      flavorRating: data.flavorRating,
+      sournessRating: data.sournessRating,
+      imageUrl: data.imageRemoved ? null : (data.imageUrl ?? data.oldImageUrl ?? null),
+      locationCity: data.locationCity || null,
+      addedBy: data.addedBy || null,
+    });
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : 'Failed to update.' };
+  }
+  revalidatePath('/');
+  return { success: true };
+}
+
+export async function logoutAdmin(): Promise<never> {
+  const supabase = await createClient();
+  await supabase.auth.signOut();
+  revalidatePath('/');
+  redirect('/');
 }

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -99,7 +99,10 @@ export async function editLemonade(data: {
   }
 
   try {
-    if (data.oldImageUrl && (data.imageRemoved || data.imageUrl)) {
+    const oldImageShouldBeDeleted =
+      data.oldImageUrl &&
+      (data.imageRemoved || (data.imageUrl && data.imageUrl !== data.oldImageUrl));
+    if (oldImageShouldBeDeleted && data.oldImageUrl) {
       await deleteStorageImage(data.oldImageUrl);
     }
     await updateLemonade(data.id, {

--- a/src/app/components/AdminEntryMenu.tsx
+++ b/src/app/components/AdminEntryMenu.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+import React, { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
+import type { Lemonade } from '@/types/lemonade';
+import { deleteLemonade } from '../actions';
+import { LemonadeFormModal } from './LemonadeFormModal';
+
+export function AdminEntryMenu({
+  entry,
+  onDeleted,
+  onEditClose,
+}: {
+  entry: Lemonade;
+  onDeleted: () => void;
+  onEditClose: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [showEdit, setShowEdit] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [dropdownRect, setDropdownRect] = useState<{ top: number; left: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open || !triggerRef.current) return;
+    const rect = triggerRef.current.getBoundingClientRect();
+    setDropdownRect({ top: rect.bottom + 2, left: rect.right - 100 });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        dropdownRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    }
+    function handleEsc(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleEsc);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleEsc);
+    };
+  }, [open]);
+
+  async function handleDelete() {
+    if (!confirm(`Delete "${entry.name}"?`)) return;
+    setDeleting(true);
+    const result = await deleteLemonade(entry.id, entry.image_url);
+    setDeleting(false);
+    setOpen(false);
+    if ('error' in result) {
+      alert(result.error);
+    } else {
+      onDeleted();
+    }
+  }
+
+  const dropdownPortal =
+    open &&
+    dropdownRect &&
+    typeof document !== 'undefined' &&
+    createPortal(
+      <div
+        ref={dropdownRef}
+        className="admin-menu-dropdown admin-menu-dropdown-portal"
+        style={{ top: dropdownRect.top, left: dropdownRect.left }}
+      >
+        <button
+          type="button"
+          className="admin-menu-item"
+          onClick={e => { e.stopPropagation(); setOpen(false); setShowEdit(true); }}
+        >
+          Edit
+        </button>
+        <button
+          type="button"
+          className="admin-menu-item admin-menu-item-danger"
+          onClick={e => { e.stopPropagation(); handleDelete(); }}
+          disabled={deleting}
+        >
+          {deleting ? 'Deleting...' : 'Delete'}
+        </button>
+      </div>,
+      document.body
+    );
+
+  return (
+    <>
+      <div className="admin-entry-menu">
+        <button
+          ref={triggerRef}
+          type="button"
+          className="admin-menu-trigger"
+          onClick={e => { e.stopPropagation(); setOpen(o => !o); }}
+          aria-label="Admin menu"
+          aria-expanded={open}
+        >
+          ⋮
+        </button>
+        {dropdownPortal}
+      </div>
+      {showEdit && (
+        <LemonadeFormModal
+          mode="edit"
+          initialData={entry}
+          onClose={() => { setShowEdit(false); onEditClose(); }}
+          onSuccess={() => { setShowEdit(false); onEditClose(); }}
+        />
+      )}
+    </>
+  );
+}

--- a/src/app/components/Leaderboard.tsx
+++ b/src/app/components/Leaderboard.tsx
@@ -1,10 +1,13 @@
 'use client';
 
 import React, { useState } from 'react';
+import { useRouter } from 'next/navigation';
 import type { Lemonade } from '@/types/lemonade';
 import { LoadingImg } from './LoadingImg';
 import { Modal } from './Modal';
 import { LemonadeFormModal } from './LemonadeFormModal';
+import { AdminEntryMenu } from './AdminEntryMenu';
+import { logoutAdmin } from '../actions';
 
 type SortKey = 'rank' | 'overall_score' | 'flavor_rating' | 'sourness_rating' | 'created_at' | 'name';
 type SortDir = 'asc' | 'desc';
@@ -22,7 +25,14 @@ function formatDate(dateStr: string) {
   return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, '0')}-${String(d.getUTCDate()).padStart(2, '0')}`;
 }
 
-export function Leaderboard({ initialData }: { initialData: Lemonade[] }) {
+export function Leaderboard({
+  initialData,
+  isAdmin = false,
+}: {
+  initialData: Lemonade[];
+  isAdmin?: boolean;
+}) {
+  const router = useRouter();
   const isTouch = useIsTouch();
   const [sortKey, setSortKey] = useState<SortKey>('rank');
   const [sortDir, setSortDir] = useState<SortDir>('asc');
@@ -73,6 +83,11 @@ export function Leaderboard({ initialData }: { initialData: Lemonade[] }) {
         <h1>
           🍋&ensp;lemolist - rank ur lemonade!
           <span className="header-links">
+            {isAdmin && (
+              <form action={logoutAdmin}>
+                <button type="submit" className="link-btn desktop-only">logout</button>
+              </form>
+            )}
             <button className="link-btn desktop-only" onClick={() => setShowRules(true)}>rules</button>
             <button className="link-btn link-btn-red desktop-only" onClick={() => setShowAddModal(true)}>add your lemonade</button>
           </span>
@@ -135,7 +150,16 @@ export function Leaderboard({ initialData }: { initialData: Lemonade[] }) {
                       <td>{entry.overall_score.toFixed(1)} ☆</td>
                       <td>{entry.flavor_rating} ☆</td>
                       <td>{entry.sourness_rating} ☆</td>
-                      <td>{formatDate(entry.created_at)}</td>
+                      <td className="cell-actions">
+                        {formatDate(entry.created_at)}
+                        {isAdmin && (
+                          <AdminEntryMenu
+                            entry={entry}
+                            onDeleted={() => router.refresh()}
+                            onEditClose={() => router.refresh()}
+                          />
+                        )}
+                      </td>
                     </tr>
                     {isExpanded && (
                       <tr className="detail-row">
@@ -198,6 +222,14 @@ export function Leaderboard({ initialData }: { initialData: Lemonade[] }) {
       <footer className="site-footer">
         help us find the best lemonade ever pls 👉👈
         <span className="footer-divider"> · </span>
+        {isAdmin && (
+          <>
+            <form action={logoutAdmin} className="footer-inline-form">
+              <button type="submit" className="link-btn">logout</button>
+            </form>
+            <span className="footer-divider"> · </span>
+          </>
+        )}
         <button className="link-btn footer-rules-link" onClick={() => setShowRules(true)}>rules</button>
       </footer>
     </>

--- a/src/app/components/LemonadeFormModal.tsx
+++ b/src/app/components/LemonadeFormModal.tsx
@@ -86,7 +86,12 @@ export function LemonadeFormModal({
       };
 
       const result = isEdit && initialData
-        ? await editLemonade({ id: initialData.id, ...payload })
+        ? await editLemonade({
+            id: initialData.id,
+            ...payload,
+            oldImageUrl: initialData.image_url ?? undefined,
+            imageRemoved,
+          })
         : await addLemonade(payload);
 
       if ('error' in result) {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -408,6 +408,110 @@ td.empty {
   margin-top: 8px;
 }
 
+.login-page {
+  max-width: 360px;
+  margin-top: 48px;
+}
+
+.login-page h1 {
+  margin-bottom: 20px;
+  border-bottom: 1px solid #d4a0a0;
+  padding-bottom: 10px;
+}
+
+.login-page form label {
+  display: block;
+  margin-bottom: 14px;
+}
+
+.login-page form input {
+  display: block;
+  width: 100%;
+  margin-top: 4px;
+  padding: 8px;
+  font-family: Verdana, Geneva, sans-serif;
+}
+
+.login-back {
+  margin-top: 20px;
+  font-size: 13px;
+}
+
+.cell-actions {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.admin-entry-menu {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.admin-menu-trigger {
+  background: none;
+  border: none;
+  padding: 2px 6px;
+  font-size: 16px;
+  line-height: 1;
+  color: #666;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.admin-menu-trigger:hover {
+  color: #333;
+}
+
+.admin-menu-dropdown {
+  position: absolute;
+  right: 0;
+  top: 100%;
+  margin-top: 2px;
+  background: #fff;
+  border: 1px solid #d4a0a0;
+  border-radius: 2px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  min-width: 100px;
+  z-index: 10;
+}
+
+.admin-menu-dropdown-portal {
+  position: fixed;
+  right: auto;
+  width: 100px;
+  min-width: 100px;
+  z-index: 1000;
+  margin-top: 0;
+}
+
+.admin-menu-item {
+  display: block;
+  width: 100%;
+  padding: 8px 12px;
+  background: none;
+  border: none;
+  font-family: Verdana, Geneva, sans-serif;
+  font-size: 13px;
+  text-align: left;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+
+.admin-menu-item:hover {
+  background: #fae8e8;
+}
+
+.admin-menu-item-danger {
+  color: #993333;
+}
+
+.admin-menu-item-danger:hover {
+  background: #f5d5d5;
+}
+
 .hover-preview {
   position: fixed;
   pointer-events: none;
@@ -450,6 +554,10 @@ td.empty {
 
 .footer-divider {
   color: rgba(153, 51, 51, 0.4);
+}
+
+.footer-inline-form {
+  display: inline;
 }
 
 .footer-rules-link {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import React, { useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setLoading(true);
+
+    try {
+      const supabase = createClient();
+      const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+
+      if (signInError) {
+        setError(signInError.message);
+        setLoading(false);
+        return;
+      }
+
+      router.push('/');
+      router.refresh();
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="login-page">
+      <h1>admin login</h1>
+      <form onSubmit={handleSubmit}>
+        <label>
+          email
+          <input
+            type="email"
+            value={email}
+            onChange={e => setEmail(e.target.value)}
+            required
+            autoComplete="email"
+          />
+        </label>
+        <label>
+          password
+          <input
+            type="password"
+            value={password}
+            onChange={e => setPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+          />
+        </label>
+        {error && <p className="error">{error}</p>}
+        <button type="submit" className="submit-btn" disabled={loading}>
+          {loading ? 'signing in...' : 'sign in'}
+        </button>
+      </form>
+      <p className="login-back">
+        <Link href="/" className="link-btn">← back to leaderboard</Link>
+      </p>
+    </main>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,20 @@
 import { getAllLemonades } from '@/services/lemonade-service';
+import { createClient } from '@/lib/supabase/server';
 import { Leaderboard } from './components/Leaderboard';
 
 export const dynamic = 'force-dynamic';
 
 export default async function HomePage() {
-  const lemonades = await getAllLemonades();
+  const [lemonades, supabase] = await Promise.all([
+    getAllLemonades(),
+    createClient(),
+  ]);
+  const { data: { user } } = await supabase.auth.getUser();
+  const isAdmin = !!user;
 
   return (
     <main>
-      <Leaderboard initialData={lemonades} />
+      <Leaderboard initialData={lemonades} isAdmin={isAdmin} />
     </main>
   );
 }

--- a/src/lib/supabase/storage.shared.ts
+++ b/src/lib/supabase/storage.shared.ts
@@ -30,3 +30,22 @@ export function getStorageBucketCandidates(configuredBucket?: string) {
     ),
   ];
 }
+
+const PUBLIC_PREFIX = '/storage/v1/object/public/';
+
+/**
+ * Parse bucket id and object path from a Supabase storage public URL.
+ * Returns null if the URL is not a valid storage public URL.
+ */
+export function parseStoragePublicUrl(
+  url: string,
+  baseUrl?: string
+): { bucket: string; path: string } | null {
+  const base = (baseUrl ?? process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() ?? '').replace(/\/$/, '');
+  const prefix = `${base}${PUBLIC_PREFIX}`;
+  if (!url.startsWith(prefix)) return null;
+  const after = url.slice(prefix.length);
+  const firstSlash = after.indexOf('/');
+  if (firstSlash === -1) return null;
+  return { bucket: after.slice(0, firstSlash), path: after.slice(firstSlash + 1) };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,29 @@
+import { createServerClient } from '@supabase/ssr';
+import { NextResponse, type NextRequest } from 'next/server';
+
+export async function middleware(request: NextRequest) {
+  const response = NextResponse.next({
+    request: { headers: request.headers },
+  });
+
+  const supabase = createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY!,
+    {
+      cookies: {
+        getAll() {
+          return request.cookies.getAll();
+        },
+        setAll(cookiesToSet) {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            response.cookies.set(name, value, options);
+          });
+        },
+      },
+    }
+  );
+
+  await supabase.auth.getUser();
+
+  return response;
+}

--- a/src/services/lemonade-service.ts
+++ b/src/services/lemonade-service.ts
@@ -1,5 +1,16 @@
 import { createClient } from '@/lib/supabase/server';
+import { parseStoragePublicUrl } from '@/lib/supabase/storage.shared';
 import { CreateLemonadeInput, Lemonade } from '@/types/lemonade';
+
+export interface UpdateLemonadeInput {
+  name: string;
+  description: string;
+  flavorRating: number;
+  sournessRating: number;
+  imageUrl?: string | null;
+  locationCity?: string | null;
+  addedBy?: string | null;
+}
 
 /**
  * Create a new lemonade entry in the database
@@ -47,4 +58,70 @@ export async function getAllLemonades(): Promise<Lemonade[]> {
   }
 
   return data || [];
+}
+
+/**
+ * Delete a storage object by its public URL (e.g. when replacing or removing an image)
+ */
+export async function deleteStorageImage(url: string): Promise<void> {
+  const parsed = parseStoragePublicUrl(url);
+  if (!parsed) return;
+  const supabase = await createClient();
+  await supabase.storage.from(parsed.bucket).remove([parsed.path]);
+}
+
+/**
+ * Delete a lemonade and its storage image if present.
+ * Row delete always runs; storage delete is best-effort (e.g. if RLS blocks it, row still deletes).
+ */
+export async function deleteLemonade(id: string, imageUrl: string | null): Promise<void> {
+  const supabase = await createClient();
+
+  const urlToRemove = typeof imageUrl === 'string' && imageUrl.trim() ? imageUrl : null;
+  if (urlToRemove) {
+    const parsed = parseStoragePublicUrl(urlToRemove);
+    if (parsed) {
+      try {
+        await supabase.storage.from(parsed.bucket).remove([parsed.path]);
+      } catch {
+        // Best-effort: row delete still runs so the entry is removed from the list
+      }
+    }
+  }
+
+  const { error } = await supabase.from('lemonades').delete().eq('id', id);
+
+  if (error) {
+    throw new Error(`Failed to delete lemonade: ${error.message}`);
+  }
+}
+
+/**
+ * Update a lemonade by id
+ */
+export async function updateLemonade(id: string, data: UpdateLemonadeInput): Promise<Lemonade> {
+  const supabase = await createClient();
+
+  const dbData = {
+    name: data.name,
+    description: data.description,
+    flavor_rating: data.flavorRating,
+    sourness_rating: data.sournessRating,
+    image_url: data.imageUrl ?? null,
+    location_city: data.locationCity ?? null,
+    added_by: data.addedBy ?? null,
+  };
+
+  const { data: result, error } = await supabase
+    .from('lemonades')
+    .update(dbData)
+    .eq('id', id)
+    .select()
+    .single();
+
+  if (error) {
+    throw new Error(`Failed to update lemonade: ${error.message}`);
+  }
+
+  return result;
 }

--- a/supabase/migrations/005_admin_update_delete_policies.sql
+++ b/supabase/migrations/005_admin_update_delete_policies.sql
@@ -1,0 +1,11 @@
+-- Allow authenticated users (admin) to update and delete lemonades
+CREATE POLICY "Authenticated users can update lemonades"
+ON public.lemonades FOR UPDATE
+TO authenticated
+USING (true)
+WITH CHECK (true);
+
+CREATE POLICY "Authenticated users can delete lemonades"
+ON public.lemonades FOR DELETE
+TO authenticated
+USING (true);

--- a/supabase/migrations/006_authenticated_storage_delete.sql
+++ b/supabase/migrations/006_authenticated_storage_delete.sql
@@ -1,0 +1,5 @@
+-- Allow authenticated users (admin) to delete objects in limo buckets
+CREATE POLICY "Authenticated users can delete limo images"
+ON storage.objects FOR DELETE
+TO authenticated
+USING (bucket_id IN ('limo-images', 'lemonade-images'));

--- a/tests/e2e/03-login.spec.ts
+++ b/tests/e2e/03-login.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('login', () => {
+  test('login page shows form and rejects invalid credentials', async ({ page }) => {
+    await page.goto('/login');
+
+    await expect(page.getByRole('heading', { name: /admin login/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+    await expect(page.getByLabel(/password/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible();
+
+    await page.getByLabel(/email/i).fill('wrong@test.local');
+    await page.getByLabel(/password/i).fill('wrong');
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page.getByText(/invalid/i).or(page.getByText(/error/i)).or(page.locator('.error'))).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('login with test admin and see logout on home', async ({ page }) => {
+    const email = process.env.TEST_ADMIN_EMAIL;
+    const password = process.env.TEST_ADMIN_PASSWORD;
+    if (!email || !password) {
+      test.skip();
+      return;
+    }
+
+    await page.goto('/login');
+    await page.getByLabel(/email/i).fill(email);
+    await page.getByLabel(/password/i).fill(password);
+    await page.getByRole('button', { name: /sign in/i }).click();
+
+    await expect(page).toHaveURL(/\/$/, { timeout: 10000 });
+    await expect(page.getByRole('button', { name: 'logout' }).first()).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/tests/e2e/04-admin-delete-edit.spec.ts
+++ b/tests/e2e/04-admin-delete-edit.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+
+function getAdminCredentials() {
+  const email = process.env.TEST_ADMIN_EMAIL;
+  const password = process.env.TEST_ADMIN_PASSWORD;
+  return email && password ? { email, password } : null;
+}
+
+async function loginAsAdmin(page: import('@playwright/test').Page) {
+  const creds = getAdminCredentials();
+  if (!creds) {
+    throw new Error('TEST_ADMIN_EMAIL and TEST_ADMIN_PASSWORD must be set for admin E2E (e2e-ci creates them)');
+  }
+  await page.goto('/login');
+  await page.getByLabel(/email/i).fill(creds.email);
+  await page.getByLabel(/password/i).fill(creds.password);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\/$/, { timeout: 10000 });
+}
+
+test.describe('admin delete and edit', () => {
+  test.beforeEach(async ({ page }) => {
+    const creds = getAdminCredentials();
+    if (!creds) test.skip();
+  });
+
+  test('admin can edit an entry', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const row = page.getByRole('cell', { name: 'E2E Test Limo' }).first();
+    await expect(row).toBeVisible({ timeout: 5000 }).catch(() => {});
+
+    const tableRow = row.locator('..');
+    const menuTrigger = tableRow.getByRole('button', { name: 'Admin menu' });
+    await menuTrigger.click();
+
+    await page.getByRole('button', { name: 'Edit' }).click();
+
+    const modal = page.getByRole('heading', { name: 'edit lemonade' });
+    await expect(modal).toBeVisible();
+
+    const nameInput = page.getByLabel(/lemonade name/i);
+    await nameInput.fill('E2E Test Limo (edited)');
+    await page.getByRole('button', { name: 'save changes' }).click();
+
+    await expect(modal).not.toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole('cell', { name: 'E2E Test Limo (edited)' }).first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin can delete an entry', async ({ page }) => {
+    await loginAsAdmin(page);
+
+    const row = page.getByRole('cell', { name: 'E2E Test Limo (edited)' }).first();
+    await expect(row).toBeVisible({ timeout: 5000 });
+
+    const tableRow = row.locator('..');
+    const menuTrigger = tableRow.getByRole('button', { name: 'Admin menu' });
+    await expect(menuTrigger).toBeVisible();
+    await menuTrigger.click();
+
+    page.once('dialog', (d) => d.accept());
+    await page.getByRole('button', { name: 'Delete' }).click();
+
+    await expect(row).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/tests/unit/admin-actions.test.ts
+++ b/tests/unit/admin-actions.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(() =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+        signOut: mockSignOut,
+      },
+    })
+  ),
+}));
+
+vi.mock('@/services/lemonade-service', () => ({
+  deleteLemonade: vi.fn(),
+  updateLemonade: vi.fn(),
+  deleteStorageImage: vi.fn(),
+}));
+
+vi.mock('next/cache', () => ({
+  revalidatePath: vi.fn(),
+}));
+
+const redirectThrow = new Error('NEXT_REDIRECT');
+vi.mock('next/navigation', () => ({
+  redirect: vi.fn(() => {
+    throw redirectThrow;
+  }),
+}));
+
+vi.mock('@/lib/image-url', () => ({
+  isAllowedImageUrl: vi.fn((url: string) =>
+    url.startsWith('https://abc123.supabase.co/storage/')
+  ),
+}));
+
+import { deleteLemonade, editLemonade, logoutAdmin } from '@/app/actions';
+import * as lemonadeService from '@/services/lemonade-service';
+import { revalidatePath } from 'next/cache';
+import { redirect } from 'next/navigation';
+
+const SUPABASE_URL = 'https://abc123.supabase.co';
+const ALLOWED_IMAGE_URL = `${SUPABASE_URL}/storage/v1/object/public/lemonades/abc.png`;
+
+describe('deleteLemonade', () => {
+  beforeEach(() => {
+    vi.mocked(lemonadeService.deleteLemonade).mockResolvedValue(undefined);
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const result = await deleteLemonade('id-1', null);
+
+    expect(result).toEqual({ error: 'Not authenticated.' });
+    expect(lemonadeService.deleteLemonade).not.toHaveBeenCalled();
+  });
+
+  it('calls service and returns success when authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: { id: 'u1' } }, error: null });
+
+    const result = await deleteLemonade('id-1', null);
+
+    expect(lemonadeService.deleteLemonade).toHaveBeenCalledWith('id-1', null);
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('passes imageUrl to service when provided', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: {} }, error: null });
+
+    await deleteLemonade('id-2', ALLOWED_IMAGE_URL);
+
+    expect(lemonadeService.deleteLemonade).toHaveBeenCalledWith('id-2', ALLOWED_IMAGE_URL);
+  });
+
+  it('returns error when service throws', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: {} }, error: null });
+    vi.mocked(lemonadeService.deleteLemonade).mockRejectedValue(new Error('DB error'));
+
+    const result = await deleteLemonade('id-1', null);
+
+    expect(result).toEqual({ error: 'DB error' });
+  });
+});
+
+describe('editLemonade', () => {
+  const validEditData = {
+    id: 'id-1',
+    name: 'Updated Limo',
+    description: 'New desc',
+    flavorRating: 8,
+    sournessRating: 6,
+    locationCity: 'Berlin',
+    addedBy: 'Tester',
+  };
+
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: {} }, error: null });
+    vi.mocked(lemonadeService.updateLemonade).mockResolvedValue({} as never);
+    vi.mocked(lemonadeService.deleteStorageImage).mockResolvedValue(undefined);
+    process.env.NEXT_PUBLIC_SUPABASE_URL = SUPABASE_URL;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns error when not authenticated', async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null }, error: null });
+
+    const result = await editLemonade(validEditData);
+
+    expect(result).toEqual({ error: 'Not authenticated.' });
+    expect(lemonadeService.updateLemonade).not.toHaveBeenCalled();
+  });
+
+  it('returns validation error for invalid payload', async () => {
+    const result = await editLemonade({
+      ...validEditData,
+      name: 'A',
+      flavorRating: 0,
+      sournessRating: 11,
+    });
+
+    expect(result).toHaveProperty('error');
+    expect((result as { error: string }).error).toBeTruthy();
+    expect(lemonadeService.updateLemonade).not.toHaveBeenCalled();
+  });
+
+  it('calls updateLemonade and returns success for valid data', async () => {
+    const result = await editLemonade(validEditData);
+
+    expect(lemonadeService.updateLemonade).toHaveBeenCalledWith('id-1', {
+      name: validEditData.name,
+      description: validEditData.description,
+      flavorRating: validEditData.flavorRating,
+      sournessRating: validEditData.sournessRating,
+      imageUrl: null,
+      locationCity: validEditData.locationCity,
+      addedBy: validEditData.addedBy,
+    });
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('calls deleteStorageImage when oldImageUrl and imageRemoved', async () => {
+    await editLemonade({
+      ...validEditData,
+      oldImageUrl: ALLOWED_IMAGE_URL,
+      imageRemoved: true,
+    });
+
+    expect(lemonadeService.deleteStorageImage).toHaveBeenCalledWith(ALLOWED_IMAGE_URL);
+    expect(lemonadeService.updateLemonade).toHaveBeenCalledWith(
+      'id-1',
+      expect.objectContaining({ imageUrl: null })
+    );
+  });
+
+  it('returns error when updateLemonade throws', async () => {
+    vi.mocked(lemonadeService.updateLemonade).mockRejectedValue(new Error('Update failed'));
+
+    const result = await editLemonade(validEditData);
+
+    expect(result).toEqual({ error: 'Update failed' });
+  });
+});
+
+describe('logoutAdmin', () => {
+  beforeEach(() => {
+    mockGetUser.mockResolvedValue({ data: { user: {} }, error: null });
+    mockSignOut.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls signOut and revalidatePath then redirects', async () => {
+    await expect(logoutAdmin()).rejects.toThrow('NEXT_REDIRECT');
+
+    expect(mockSignOut).toHaveBeenCalled();
+    expect(revalidatePath).toHaveBeenCalledWith('/');
+    expect(redirect).toHaveBeenCalledWith('/');
+  });
+});


### PR DESCRIPTION
## Summary

- Admin mode for the leaderboard. just adds a new col to the table with three dots menu to edit/delete. login through /login, no extra button or anything available. create user in supabase dashboard.  

## Resolves Issue #16 

- Linear:
- Why:

## Testing

- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test`
- [x] `npm run build`
- [x] `npm run test:e2e` (when core flow or UI behavior changed)

## Verification Notes

- Included new tests

## Risks

- no clue. should be checked for problems/edge cases. @claude roast it

## Docs

- [x] Docs updated

## UI Changes

- [ ] Screenshot attached (if UI changed)
